### PR TITLE
Set from format to 'md'

### DIFF
--- a/setuptools_markdown.py
+++ b/setuptools_markdown.py
@@ -19,7 +19,7 @@ def long_description_markdown_filename(dist, attr, value):
     markdown_filename = os.path.join(os.path.dirname(setup_py_path), value)
     logger.debug('markdown_filename = %r', markdown_filename)
     try:
-        output = pypandoc.convert(markdown_filename, 'rst')
+        output = pypandoc.convert(markdown_filename, 'rst', format='md')
     except OSError:
         output = open(markdown_filename).read()
     dist.metadata.long_description = output


### PR DESCRIPTION
As pypandocs auto detect sometimes doesn't work, and this package is only for md files, I think it's best to avoid this potential error by hard-coding the from format.
