### PR TITLE
Closes #10: Don't allow second line to be blank.

### DIFF
--- a/setuptools_markdown.py
+++ b/setuptools_markdown.py
@@ -22,7 +22,7 @@ def long_description_markdown_filename(dist, attr, value):
         output = pypandoc.convert(markdown_filename, 'rst')
     except OSError:
         output = open(markdown_filename).read()
-    lines = output.splitlines()
+    lines = output.strip().splitlines()
     while len(lines) >= 2 and (not lines[1] or lines[1].isspace()):
         del lines[1]
     

--- a/setuptools_markdown.py
+++ b/setuptools_markdown.py
@@ -22,6 +22,11 @@ def long_description_markdown_filename(dist, attr, value):
         output = pypandoc.convert(markdown_filename, 'rst')
     except OSError:
         output = open(markdown_filename).read()
+    lines = output.splitlines()
+    while len(lines) >= 2 and (not lines[1] or lines[1].isspace()):
+        del lines[1]
+    
+    output = '\n'.join(lines)
     dist.metadata.long_description = output
 
 


### PR DESCRIPTION
bdist_wheel does not allow the second line to be blank in RST descriptions.