### PR TITLE
Include license file into sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE-MIT


### PR DESCRIPTION
Hi,

I'm about to create a conda package for this project, but noticed that the license file is missing from the source distribution.

By adding a `MANIFEST.in` file the license is included:

```
creating setuptools-markdown-0.2
creating setuptools-markdown-0.2\setuptools_markdown.egg-info
copying files to setuptools-markdown-0.2...
copying LICENSE-MIT -> setuptools-markdown-0.2
copying MANIFEST.in -> setuptools-markdown-0.2
copying README.rst -> setuptools-markdown-0.2
copying setup.cfg -> setuptools-markdown-0.2
copying setup.py -> setuptools-markdown-0.2
```