### PR TITLE
Use m2r instead of pypandoc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,10 +8,6 @@ project description
 Install
 =======
 
-1. Install `pandoc <http://johnmacfarlane.net/pandoc/>`_
-
-2. Install this module
-
 .. code:: console
 
     pip install setuptools-markdown
@@ -36,6 +32,6 @@ Use
 
 The plugin will read the specified file, convert it to
 `reST <http://en.wikipedia.org/wiki/ReStructuredText>`__ using
-`pypandoc <https://pypi.python.org/pypi/pypandoc>`__ and store the
+`m2r <https://github.com/miyakogi/m2r>`__ and store the
 resulting reST in the ``long_description`` metadata field of your
 distribution.

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     description="Use Markdown for your project description",
     long_description=long_description,
     license='MIT',
-    install_requires=['pypandoc'],
+    install_requires=['m2r'],
     py_modules=['setuptools_markdown'],
     zip_safe=False,
     entry_points="""

--- a/setuptools_markdown.py
+++ b/setuptools_markdown.py
@@ -23,7 +23,7 @@ import inspect
 import os
 import logging
 
-import pypandoc
+import m2r
 
 
 logging.basicConfig(level=logging.INFO)
@@ -39,10 +39,7 @@ def long_description_markdown_filename(dist, attr, value):
     setup_py_path = inspect.getsourcefile(frame)
     markdown_filename = os.path.join(os.path.dirname(setup_py_path), value)
     logger.debug('markdown_filename = %r', markdown_filename)
-    try:
-        output = pypandoc.convert(markdown_filename, 'rst', format='md')
-    except OSError:
-        output = open(markdown_filename).read()
+    output = m2r.parse_from_file(markdown_filename)
     lines = output.strip().splitlines()
     while len(lines) >= 2 and (not lines[1] or lines[1].isspace()):
         del lines[1]


### PR DESCRIPTION
Pypandoc causes a lot of headaches:
- pandoc is sometimes difficult to install
- pypandoc is not compatible with the latest version of pandoc

M2r provides a lightweight, pure-Python alternative.