### PR TITLE
Use `pypandoc.convert_text` instead of `pypandoc.convert`

### DIFF
--- a/setuptools_markdown.py
+++ b/setuptools_markdown.py
@@ -40,7 +40,7 @@ def long_description_markdown_filename(dist, attr, value):
     markdown_filename = os.path.join(os.path.dirname(setup_py_path), value)
     logger.debug('markdown_filename = %r', markdown_filename)
     try:
-        output = pypandoc.convert(markdown_filename, 'rst', format='md')
+        output = pypandoc.convert_text(markdown_filename, 'rst', format='md')
     except OSError:
         output = open(markdown_filename).read()
     lines = output.strip().splitlines()


### PR DESCRIPTION
Currently, pypandoc does not have `convert` function. https://github.com/NicklasTegner/pypandoc/blob/master/pypandoc/__init__.py
pypandoc only has `convert_file` or `convert_text`.

Actually pypandoc previously have `convert` function like https://github.com/NicklasTegner/pypandoc/blob/c06d7b64a58729fa174b7721dac6c600fad166af/pypandoc/__init__.py